### PR TITLE
Include `stac_version` in include recommendations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,15 @@
 # Changelog
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- `stac_version` to the include recommendations.
 
 ## [v1.0.0-rc.2] - TBD
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ name, e.g., `properties.datetime` or `datetime`.
 
 1. If `fields` attribute is specified with an empty object, or with both `include` and `exclude` set to null or an 
 empty array, the recommended behavior is as if `include` was set to 
-`["id", "type", "geometry", "bbox", "links", "assets", "properties.datetime"]`.  This default is so that the entity 
+`["id", "type", "stac_version", "geometry", "bbox", "links", "assets", "properties.datetime"]`.  This default is so that the entity 
 returned is a valid STAC Item.  Implementations may choose to add other properties, e.g., `created`, but the number 
 of default properties attributes should be kept to a minimum.
 2. If only `include` is specified, these attributes are added to the default set of attributes (set union operation). 


### PR DESCRIPTION
**Proposed Changes:**

1. Add `stac_version` to the list of fields recommended to include by default

**PR Checklist:**

- [x] This PR has **no** breaking changes.
- [x] I have added my changes to the [CHANGELOG](https://github.com/stac-api-extensions/fields/blob/main/CHANGELOG.md) **or** a CHANGELOG entry is not required.
