### PR TITLE
Change include/exclude recommendations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,15 @@
 # Changelog
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Changed
+
+- Include/exclude semantics are more precisely defined ([#5](https://github.com/stac-api-extensions/fields/pull/5))
 
 ## [v1.0.0-rc.2] - 2022-11-01
 


### PR DESCRIPTION
**Related Issue(s):** 

- Closes #4 (this PR supersedes)
- Discussions and related PRs:
  - https://github.com/stac-utils/stac-fastapi/issues/395#issuecomment-1432502676
  - https://github.com/stac-utils/stac-fastapi/pull/527#issuecomment-1431775940
  - https://github.com/stac-utils/stac-fastapi/pull/524

**Proposed Changes:**

1. Change the recommended `include` semantics to only return what's asked for. Previously, the recommendation was to return what was asked for AND the default fields.
2. Include `stac_version` in the default fields.
3. Clarify the wording around sub-keys.
4. Define behavior when a field is both included and excluded.
5. Update examples
6. Fix some formatting in the examples

**PR Checklist:**

- [x] This PR has **no** breaking changes.
- [x] I have added my changes to the [CHANGELOG](https://github.com/stac-api-extensions/fields/blob/main/CHANGELOG.md) **or** a CHANGELOG entry is not required.
